### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,47 +1,47 @@
 HOWTO deploy on Linode
 ======================
 
-###Build Ubuntu 12.10 on Linode and access the server
+### Build Ubuntu 12.10 on Linode and access the server
 	$ ssh root@106.187.xxx.xxx
 	# ssh to server
 	# if encounter 'Host key verification failed', just delete ~/.ssh/known_hosts file
 
-###Install Mysql
+### Install Mysql
 	$ apt-get update
 	$ apt-get install mysql-server mysql-client
 
-###Installing tools and dependencies
+### Installing tools and dependencies
 	$ apt-get install python-setuptools 
 	$ easy_install pip 
 	$ apt-get install git 
 	$ apt-get install nginx 
 	$ pip install supervisor 
 
-###Config Git
+### Config Git
 	$ ssh-keygen -t rsa -C "3n1b.com@gmail.com"
 	$ cat ~/.ssh/id_rsa.pub
 	# copy and paste the RSA key to the Deploy keys setting
 	$ git config --global user.name "3n1b.com"  
 	$ git config --global user.email 3n1b.com@gmail.com  
 
-###Make directories for your app
+### Make directories for your app
 	$ mkdir /srv/www
 
-###Pull in source code
+### Pull in source code
 	$ cd /srv/www/
 	$ git clone git@github.com:gaolinjie/3n1b.com.git
 	$ cd 3n1b.com
 
-###Install web app required modules
+### Install web app required modules
 	$ pip install -r requirements.txt
 
-###Install python mysql
+### Install python mysql
 	$ easy_install -U distribute
 	$ apt-get install libmysqld-dev libmysqlclient-dev
 	$ pip install mysql-python
 	$ apt-get install python-MySQLdb
 
-###Install PIL
+### Install PIL
 	$ apt-get build-dep python-imaging 
 	$ apt-get install libjpeg8 libjpeg62-dev libfreetype6 libfreetype6-dev
 	$ ln -s /usr/lib/x86_64-linux-gnu/libjpeg.so /usr/lib
@@ -50,7 +50,7 @@ HOWTO deploy on Linode
 	$ pip install -U PIL
 	# pip install http://effbot.org/downloads/Imaging-1.1.7.tar.gz
 
-###Create database and then execute sql file in dbstructure/
+### Create database and then execute sql file in dbstructure/
 	$ mysql -u root -p
 	mysql> CREATE DATABASE 3n1b;
 	mysql> GRANT ALL PRIVILEGES ON 3n1b.* TO '3n1b'@'localhost' IDENTIFIED BY '3n1b';
@@ -64,25 +64,25 @@ HOWTO deploy on Linode
 	$ mysql -u 3n1b -p --database=3n1b < dbstructure/follow.sql
 	$ mysql -u 3n1b -p --database=3n1b < dbstructure/message.sql
 
-###Create symbolic links to conf files
+### Create symbolic links to conf files
 	$ cd /etc/nginx 
 	$ rm nginx.conf
 	$ ln -s /srv/www/3n1b.com/conf/nginx.conf nginx.conf 
 	$ cd
 	$ ln -s /srv/www/3n1b.com/conf/supervisord.conf supervisord.conf  
 
-###Create nginx user
+### Create nginx user
 	$ adduser --system --no-create-home --disabled-login --disabled-password --group nginx 
 
-###Create a logs directory:
+### Create a logs directory:
 	$ mkdir ~/logs 
 
-###Start Supervisor and Nginx
+### Start Supervisor and Nginx
 	$ supervisord
 	$ /etc/init.d/nginx start
 
-###Visit your public IP address and enjoy!
+### Visit your public IP address and enjoy!
 
-###Update your web app
+### Update your web app
 	$ cd /srv/www/3n1b.com
 	$ git pull

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ wtforms
 nginx  
 supervisor  
 
-#####部署教程在HOWTO文档中
+##### 部署教程在HOWTO文档中
   
 ❤ Inspired by f2e.im and v2ex.com


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
